### PR TITLE
Timestamp is in seconds

### DIFF
--- a/blip-0010.md
+++ b/blip-0010.md
@@ -48,7 +48,7 @@ Identifying the episode **recommended**: use any of `episode`, `itemID` or `epis
 
 Information about time within the episode **recommended**: use any of `time`, `ts`. **ts preferred**
 * `time` (str) HH:MM:SS timestamp when the boost/stream was sent WITHIN the episode (playback position)
-* `ts` (int) Timestamp when the boost/stream was sent WITHIN the episode (playback position)
+* `ts` (int) Timestamp when the boost/stream was sent WITHIN the episode, in seconds (playback position)
 
 Rest of keys:
 * `action` **recommended**: (str) "boost" or "stream"


### PR DESCRIPTION
Define timestamp is in seconds.


https://github.com/lightning/blips/issues/12