### PR TITLE
keysend: correct TLV extension field table

### DIFF
--- a/blip-0002.md
+++ b/blip-0002.md
@@ -86,6 +86,7 @@ The following table contains extension tlv fields for the `payment_onion_payload
 | Type        | Name                        | Link                           |
 |-------------|-----------------------------|--------------------------------|
 | 7629169     | `podcasting_2_0`            | [bLIP 10](./blip-0010.md)      |
+| 5482373484  | `keysend_preimage`          | [bLIP 3](./blip-0003.md)       |
 
 
 #### `ping`
@@ -95,14 +96,6 @@ The following table contains extension tlv fields for the `ping` message:
 | Type  | Name                        | Link                           |
 |-------|-----------------------------|--------------------------------|
 | 65536 | `tlv_field_name`            | Link to the corresponding bLIP |
-
-#### `update_add_htlc`
-
-The following table contains extension tlv fields for the `update_add_htlc` message's onion payload:
-
-| Type       | Name                        | Link                           |
-|------------|-----------------------------|--------------------------------|
-| 5482373484 | `keysend_preimage`          | [bLIP 3](./blip-0003.md)       |
 
 ## Copyright
 


### PR DESCRIPTION
Keysend's TLV extension type was documented the wrong (and indeed bogus) table, as pointed out by @joostjager [here](https://github.com/lightning/blips/pull/5#discussion_r799291268)