### PR TITLE
bLIP-0011: Add Open Bitcoin Wallet to references

### DIFF
--- a/blip-0011.md
+++ b/blip-0011.md
@@ -84,3 +84,4 @@ This does not have backwards compatibility concerns.
 
 * Blixt Wallet: <https://github.com/hsjoberg/blixt-wallet/commit/e0ab93fdbaa92ec56bf920803bae22bf9108dfc4>
 * lntxbot: <https://github.com/fiatjaf/lntxbot/commit/3bde760066ad5ae20e0672a53cdbd910f14d7149>
+* Open Bitcoin Wallet: <https://github.com/nbd-wtf/obw/commit/e2b222db5ad92d8f348da4845b4e9fe3bf3c4917>


### PR DESCRIPTION
Just lil' PR to add OBW to the list of NameDesc references.