### PR TITLE
blip2: add advisory for invoice feature bit maximum

### DIFF
--- a/blip-0002.md
+++ b/blip-0002.md
@@ -40,6 +40,7 @@ network split.
 Feature bits are specified in [Bolt 9](https://github.com/lightning/bolts/blob/master/09-features.md).
 They let nodes publicly advertise that they support or require a given feature.
 Feature bits in the `0`-`255` range are reserved for BOLTs: bLIPs must use feature bits above that range.
+Custom feature bits used in the `I` [Bolt 11](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md) context must be <= 5114 due to the [size limitations on tagged fields](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md#tagged-fields).
 
 bLIPs may reserve feature bits by adding them to the following table:
 


### PR DESCRIPTION
Tagged fields in bolt11 invoices are limited to 10 bits to express the length of the field, which means we have 1023 * 5 ( = 5115) bits for features. Including a 0 position feature, this means that invoice feature bits must be <= 5114. In practice we hope and pray to never see 639 byte feature vectors, this is worth accounting for when implementing custom features.

This limitation does not apply in other contexts, because feature vectors are encoded with (u16) variable length. 