### PR TITLE
blip-40: Route Blinding Dummy Hops

### DIFF
--- a/blip-0002.md
+++ b/blip-0002.md
@@ -112,6 +112,17 @@ The following table contains extension tlv fields for the `ping` message:
 |-------|-----------------------------|--------------------------------|
 | 65536 | `tlv_field_name`            | Link to the corresponding bLIP |
 
+
+### `encrypted_data`
+
+The following table contains extension tlv fields for the `encrypted_data` field
+of an [onion `payload`](https://github.com/lightning/bolts/blob/master/04-onion-routing.md#payload-format).
+
+| Type  | Name                  | Link                      |
+|-------|-----------------------|---------------------------|
+| 65536 | `next_dummy_priv_key` | [bLIP 40](./blip-0040.md) |
+
+
 ### Onion Messages
 
 The following table contains tlv fields for use in onion messages as the payload type:

--- a/blip-0040.md
+++ b/blip-0040.md
@@ -1,0 +1,79 @@
+```
+bLIP: 40
+Title: Route Blinding Dummy Hops
+Author: Elle Mouton <elle.mouton@gmail.com>
+Status: Draft
+Created: 2024-07-08
+License: CC0
+```
+
+## Abstract
+
+This bLIP defines a new TLV field for the `encrypted_data` TLV stream of the 
+onion `payload` type. This new field can be used by the creator of a route 
+blinding path to encode the private key to use for peeling off dummy hops from
+the onion.
+
+## Copyright
+
+This bLIP is licensed under the CC0 license.
+
+## Motivation
+
+During the construction of a blinded path to itself, a recipient node may choose
+to append a number of dummy hops to the blinded path in order to manipulate its 
+anonymity set. However, the recipient will still want to be able to decrypt 
+data from the user of the blinded path for those dummy hops. For example, if the
+blinded route is being used in the context of a blinded payment, then the 
+recipient will still need to verify the `payload` values set by the sender for
+each dummy hop, and it will also need the `payload` values from the sender for
+the very last hop of the blinded route since the sender will include certain 
+values (such as `total_amount_msat`) only in that last payload. This bLIP 
+therefore defines a simple way for a recipient to construct a blinded path with 
+dummy hops such that it can then peel those dummy hops again when the time 
+comes.
+
+## Specification
+
+The following new TLV field is defined for the `encrypted_data` TLV stream 
+of the onion `payload` type:
+
+1. type: 65536 (`next_dummy_priv_key`)
+2. data:
+   * [`point`:`next_dummy_priv_key`]
+
+
+During the construction of a blinded path:
+
+* For each dummy hop it wishes to append to the route, it should derive a new 
+  private-public key pair to use for that hop. The public key will be used as 
+  the `node_id` of that hop during blinded route construction.
+* The contents of the final dummy hop's `encrypted_data` payload should contain 
+  any fields (such as the `path_id` and `payment_constraints` fields) that the 
+  route constructor would have included for the final hop of a normal blinded 
+  path.
+* For each dummy hop before the final one and for the last non-blinded hop, the
+  contents of the `encrypted_data` for those hops should include the
+  `next_dummy_priv_key` field which must contain the encoded private key to use
+  to peel the next layer of the onion. The `encrypted_data` should also include
+  any other fields that would normally be included in a non-final blinded path 
+  hop (such as `payment_relay` and `payment_constraints` in the context of 
+  blinded payments).
+* Appropriate pseudo relay policies should be chosen for each dummy hop. 
+* The blinded route construction can then take place as usual.
+
+During onion processing time: 
+
+* If an incoming onion has an `encrypted_data` field with a 
+  `next_dummy_priv_key` present, this signals that the processing node is the
+  final node in the path and that it must peel the onion until it reaches the 
+  final payload. It peels the onion using the `next_dummy_priv_key` as its node 
+  key. 
+* The payload from the sender should be validated for each dummy hop as 
+  otherwise this could create a probing vector.
+
+## Reference Implementation 
+
+A reference implementation has been completed in [this][impl] LND PR.
+
+[impl]: https://github.com/lightningnetwork/lnd/pull/8735


### PR DESCRIPTION
This bLIP defines a new TLV field, `next_dummy_priv_key` for the `encrypted_data` 
TLV stream of the onion `payload` type. This new field can be used by the creator of 
a route blinding path to encode the private key to use for peeling off dummy hops from
the onion. This gives a recipient an easy way of identifying when it is the real final hop in 
a path and should therefore continue peeling the onion since only dummy hops remain. 
Using this method, the recipient also does not need to persist any extra data in order to
peel the dummy hops.