### PR TITLE
Update bLIP 32 to point to BOLT 12 for name/domain inclusion

### DIFF
--- a/blip-0032.md
+++ b/blip-0032.md
@@ -83,8 +83,7 @@ payment instructions. A current draft may be found at
 Secondly, this document describes a method of fetching DNSSEC proofs without exiting the lightning
 network.
 
-Finally, a forthcoming bLIP will define a method to include the `user` part of the human-readable
-name used to look up an `offer` in the `invoice_request`.
+Finally, BOLT 12 specifies the inclusion of `name` and `domain` parts in its `invoice_request`s.
 
 #### Payer Protocol
 
@@ -105,7 +104,8 @@ resulting URI. If it finds an `lno` query parameter, its value should contain a 
 the payer can simply pay.
 
 In order to allow for a static offer receiving funds on behalf of many users, the payer should
-include the `user` from their original query in the `invoice_request` they send the recipient.
+include the `user` and `domain` from their original query in the `invoice_request` they send the
+recipient.
 
 #### Recipient Configuration
 


### PR DESCRIPTION
Placing BIP 353 name/domain entries in BOLT 12 `invoice_request`s ended up being done in BOLT 12 (in
https://github.com/lightning/bolts/pull/1180) rather than a bLIP, so we should make reference to that.