### PR TITLE
Clean-up duplicate section in bLIP-0002

### DIFF
--- a/blip-0002.md
+++ b/blip-0002.md
@@ -109,9 +109,10 @@ The following table contains extension tlv fields for the `payment_onion_payload
 
 The following table contains extension tlv fields for the `update_add_htlc` message:
 
-| Type  | Name                        | Link                           |
-|-------|-----------------------------|--------------------------------|
-| 65537 | `extra_fee`                 | [bLIP 25](./blip-0025.md)      |
+| Type   | Name                        | Link                           |
+|--------|-----------------------------|--------------------------------|
+| 106823 | `endorsed`                  | [bLIP 4](./blip-0004.md)       |
+| 65537  | `extra_fee`                 | [bLIP 25](./blip-0025.md)      |
 
 #### `ping`
 
@@ -129,14 +130,6 @@ The following table contains tlv fields for use in onion messages as the payload
 |-------|-----------------------------|--------------------------------|
 | 65536 | `dnssec_query`              | [bLIP 32](./blip-0032.md)      |
 | 65538 | `dnssec_proof`              | [bLIP 32](./blip-0032.md)      |
-
-#### `update_add_htlc`
-
-The following table contains extension tlv fields for the `update_add_htlc` message:
-
-| Type   | Name                        | Link                           |
-|--------|-----------------------------|--------------------------------|
-| 106823 | `endorsed`                  | [bLIP 4](./blip-0004.md)       |
 
 ## Copyright
 


### PR DESCRIPTION
It looks like two PRs added the `update_add_htlc` section and this wasn't correctly merged.