### PR TITLE
Typo corrections

### DIFF
--- a/blip-0003.md
+++ b/blip-0003.md
@@ -45,7 +45,7 @@ Receiver:
 
 A convenience of layer 1 bitcoin is being able to spontaneously send to a
 bitcoin address with no advance work required on the part of the payee. Keysend
-brings the convenience of sponaneous payments to layer 2 (with a few caveats,
+brings the convenience of spontaneous payments to layer 2 (with a few caveats,
 see the [Drawbacks](#keysend-drawbacks) section).
 
 As previously mentioned, keysend also has the advantage of already being

--- a/blip-0017.md
+++ b/blip-0017.md
@@ -88,7 +88,7 @@ and must be provided in case HOST wants to terminate the channel but cannot cont
 CLIENT.
 
 The `secret` is an optional blob that can be used by HOST to tweak channel parameters
-in multiple ways: offer an initial balance, tweak the capacity, only allow cliets with
+in multiple ways: offer an initial balance, tweak the capacity, only allow clients with
 a given secret etc.
 
 Upon receiving an `invoke_hosted_channel` message, the HOST, if willing to establish the


### PR DESCRIPTION
### Description

Added typo corrections to documentation for the following files:

**blip-0003.md**

"sponaneous" correct spelling: "spontaneous"  Corrected.

**blip-0017.md**

"cliets" correct spelling: "clients". Corrected.

### Goal

Correct grammatical errors and improve readability of the documentation.