### PR TITLE
fix: link to Torv3 hidden service specification

### DIFF
--- a/blip-0050.md
+++ b/blip-0050.md
@@ -899,7 +899,7 @@ parts:
     specifications:
     * [IPv4 addresses](https://datatracker.ietf.org/doc/html/rfc4001).
     * [IPv6 addresses](https://datatracker.ietf.org/doc/html/rfc5952).
-    * [A Torv3 hidden service](https://gitweb.torproject.org/torspec.git/tree/proposals/224-rend-spec-ng.txt).
+    * [A Torv3 hidden service](https://spec.torproject.org/rend-spec/index.html).
     * A DNS-resolvable name.
 3.  A port number, which is started by the last `:`
     in the string, and is a decimal text representation of


### PR DESCRIPTION
The old link: [A Torv3 hidden service](https://gitweb.torproject.org/torspec.git/tree/proposals/224-rend-spec-ng.txt) does not exist