### PR TITLE
bLIP-0052: Add ongoing proportional fees

### DIFF
--- a/blip-0052.md
+++ b/blip-0052.md
@@ -224,6 +224,7 @@ Example `lsps2.get_info` result:
         {
             "min_fee_msat": "546000",
             "proportional": 1200,
+            "ongoing_proportional": 1000,
             "valid_until": "2023-02-23T08:47:30.511Z",
             "min_lifetime": 1008,
             "max_client_to_self_delay": 2016,
@@ -234,6 +235,7 @@ Example `lsps2.get_info` result:
         {
             "min_fee_msat": "1092000",
             "proportional": 2400,
+            "ongoing_proportional": 500,
             "valid_until": "2023-02-27T21:23:57.984Z",
             "min_lifetime": 1008,
             "max_client_to_self_delay": 2016,
@@ -250,8 +252,8 @@ The LSP MAY return an empty array; in which case, the client currently
 cannot use JIT Channels with this LSP.
 
 An `opening_fee_params` object describes how much the LSP will charge for a
-channel open, what payment sizes it will accept, and until when the described
-parameters will be considered valid.
+channel open, what payment sizes it will accept, ongoing fees for subsequent
+payments, and until when the described parameters will be considered valid.
 An `opening_fee_params` object MUST have all of the following fields,
 and MUST NOT have any additional fields:
 
@@ -266,6 +268,12 @@ and MUST NOT have any additional fields:
   If the proportional fee is less than the `min_fee_msat`, then the
   `min_fee_msat` is paid instead of the proportional times payment size
   divided by 1 million.
+  [<LSPS0.ppm>][]
+* `ongoing_proportional` is a parts-per-million number that describes how many
+  millisatoshis to charge for every 1 million millisatoshis of payment
+  size for each payment after the first payment that opened the channel.
+  This fee is charged on every forwarded payment through the channel after
+  the initial channel-opening payment.
   [<LSPS0.ppm>][]
 * `valid_until` is a datetime (as an ISO8601 string) up to which this specific
   `opening_fee_params` is valid, and also serves as the timeout for the JIT
@@ -294,8 +302,8 @@ and MUST NOT have any additional fields:
   to the client, not including the forwarding fees of nodes along the way.
 * `promise` is an arbitrary LSP-generated string that proves to the LSP that
   it has promised a specific `opening_fee_params` with the specific
-  `min_fee_msat`, `proportional`, `valid_until`, `min_lifetime`,
-  `max_client_to_self_delay`, `min_payment_size_msat`, and
+  `min_fee_msat`, `proportional`, `ongoing_proportional`, `valid_until`, 
+  `min_lifetime`, `max_client_to_self_delay`, `min_payment_size_msat`, and
   `max_payment_size_msat`.
 
 > **Rationale** A "minimum" fee is used instead of an additive base fee as
@@ -553,6 +561,7 @@ Example `lsps2.buy` request parameters:
     "opening_fee_params": {
         "min_fee_msat": "546000",
         "proportional": 1200,
+        "ongoing_proportional": 1000,
         "valid_until": "2023-02-23T08:47:30.511Z",
         "min_lifetime": 1008,
         "max_client_to_self_delay": 2016,
@@ -1028,6 +1037,33 @@ for the specified client, up to until the `valid_until` time
 selected.
 LSPs MUST consider this alias not just for forwarded payments, but
 also for onion messages.
+
+#### Ongoing Proportional Fees
+
+For all payments forwarded through the channel after the initial
+channel-opening payment, the LSP MUST charge an ongoing proportional
+fee as specified in the `ongoing_proportional` field from the
+`opening_fee_params` used to open the channel.
+
+The ongoing fee for each payment is computed as:
+
+    ongoing_fee = ((payment_amount_msat * ongoing_proportional) + 999999) / 1000000
+
+Where `payment_amount_msat` is the amount being forwarded to the client,
+and `ongoing_proportional` is the value from the `opening_fee_params`.
+
+* All numbers MUST be computed using the same overflow detection rules
+  specified in the "Computing The `opening_fee`" section.
+* The LSP MUST deduct this `ongoing_fee` from each forwarded payment.
+* The LSP MUST include an `extra_fee` TLV (type 65537) in the
+  `update_add_htlc` message for each payment that has ongoing fees
+  deducted, with the value set to the computed `ongoing_fee`.
+* The client MUST accept these fee deductions and validate that the
+  `extra_fee` matches the expected `ongoing_fee` calculation.
+
+This ongoing fee allows LSPs to distribute the cost of channel opening
+across the lifetime of the channel rather than charging the full amount
+upfront on the first payment.
 
 [<LSPS0.msat>]: ./blip-0050.md#link-lsps0msat
 [<LSPS0.ppm>]: ./blip-0050.md#link-lsps0ppm


### PR DESCRIPTION
Adds support for ongoing proportional fees to the bLIP-0052 flow.  

This allows the LSP to charge ongoing proportional fees taken from all subsequent payments forwarded over the channel after open.  The fees are paid for by the recipient just like the opening fee is by skimming it from the HTLCs forwarded.

Ongoing fees allow the LSP to distribute the costs across the lifetime of the channel instead of charging for it all up front.