### PR TITLE
LSPS5: clarify per-method cooldown to minutes

### DIFF
--- a/blip-0055.md
+++ b/blip-0055.md
@@ -73,7 +73,7 @@ push notifications to be sent to actual mobile devices.
 Depending on architecture, the 'notification delivery service'
 and the 'mobile OS server' may not exist.
 For instance, a client running on a desktop environment might
-be able to periodically wake up and pool a 'notification
+be able to periodically wake up and poll a 'notification
 delivery service' without help from any kind of 'mobile OS
 server'.
 A client running on an environment where some DNS-resolvable
@@ -274,12 +274,12 @@ via the `lsps5.remove_webhook` call, which takes the parameters:
 
 ```JSON
 {
-  "app_name": "Another Wallet With The Same Signig Device"
+  "app_name": "Another Wallet With The Same Signing Device"
 }
 ```
 
 The following error is defined for `remove_webhook` (error
-`code` in parantheses):
+`code` in parentheses):
 
 * `app_name_not_found` (1010) - The specified `app_name` was
   not found.


### PR DESCRIPTION
I received feedback on the LSPS5 reference implementation (see https://github.com/lightningdevkit/rust-lightning/pull/3975#discussion_r2254509585) that an hour-scale cooldown is too high. If two payments arrive an hour apart, missing the first wakeup should not block sending another, since phones can be offline, low battery, or briefly unable to wake. Several notifications per hour should be acceptable.

Also a few typos are fixed