### PR TITLE
LSPS2: Support splice-in for JIT provisioning

### DIFF
--- a/blip-0052.md
+++ b/blip-0052.md
@@ -159,8 +159,9 @@ Overview:
 * The client hands the invoice to whoever it will receive funds from.
 * The payment is forwarded to the LSP.
 * The LSP recognizes the next hop SCID as being a JIT channel request,
-  and opens a 0-confirmation channel to the client, which must be
-  connected to the LSP at that time.
+  and either opens a 0-confirmation channel to the client or performs a
+  splice-in on an existing channel. The client must be connected to the LSP
+  during this step.
 * The LSP forwards the payment to the client, deducting the channel
   opening fee.
 * The client claims the payment.
@@ -809,20 +810,23 @@ where the next hop is `jit_channel_scid`, before
 * MUST check that `opening_fee + htlc_minimum_msat <= htlc_value_msat`,
   and if that fails, MUST fail with `unknown_next_peer`.
 
-### 5.  Channel Opening And Forwarding
+### 5.  Channel Provisioning And Forwarding
 
-The LSP requests a channel open to the client via standard
-[BOLT2 Channel Establishment][] flow.
+The LSP requests a channel open to the client or negotiates a splice-in on
+an existing channel with the client, via standard [BOLT2 Channel Establishment][]
+or [Splicing][] flows.
 
 [BOLT2 Channel Establishment]: https://github.com/lightning/bolts/blob/c4c5a8e5fb30b1b99fa5bb0aba7d0b6b4c831ee5/02-peer-protocol.md#channel-establishment
+[Splicing]: https://github.com/lightning/bolts/pull/1160/files
 
-The LSP selects the channel size.
-The LSP MUST ensure the channel is large enough to transmit the
-`payment_size_msat - opening_fee`, plus any reserve needed on the LSP
-side.
+The LSP determines the funding delta and resulting channel balances.
+The LSP MUST ensure the resulting channel balances allow forwarding at least
+`payment_size_msat - opening_fee`, plus any reserve needed on the LSP side.
 
-The LSP and client MUST negotiate these options and parameters in
-their [BOLT2 Channel Establishment][] flow:
+The LSP MAY choose to splice-in instead of open a new channel.
+
+If opening a new channel, the LSP and client MUST negotiate the following in their
+[BOLT2 Channel Establishment][] flow:
 
 * `option_scid_alias` is set.
 * `announce_channel` is `false`.
@@ -834,6 +838,41 @@ their [BOLT2 Channel Establishment][] flow:
 > confirms.
 >
 > `option_scid_alias` requires that `announce_channel` be `false`.
+
+Splicing Option:
+
+* If the LSP and client already share a channel that supports splicing (i.e.,
+  splicing was negotiated for that specific channel per [Splicing][]),
+  the LSP MAY satisfy an LSPS2 buy by performing a splice-in instead of opening
+  a new channel. This choice does not change any LSPS2 messages or parameters
+  and is transparent to the client.
+* When choosing splicing, the LSP SHOULD splice-in the full amount of the
+  incoming payment (subject to the same fee deductions defined in this bLIP),
+  so the client can receive the entire payment without additional steps.
+
+> **Rationale** LSPS2 aims to provision enough inbound liquidity for the
+> incoming payment. Whether this is done via a new channel or a splice-in is
+> an implementation choice with no changes to LSPS2 messages or parameters.
+> Allowing splice-in avoids unnecessary new channels and improves liquidity
+> management.
+
+When forwarding after splicing:
+
+* If satisfying an LSPS2 buy via splice-in, the LSP MUST forward only after the
+  channel is no longer quiescent, i.e., after both peers have exchanged the
+  `tx_signatures` message for the splice transaction per [Splicing][]. The LSP
+  MUST NOT require the `splice_locked` message before forwarding.
+* If the client disconnects or the splice negotiation fails before `tx_signatures`
+  are exchanged, the LSP MUST fail the incoming payment parts with
+  `temporary_channel_failure`.
+
+Timeouts and fallback:
+
+* The `opening_fee_params.valid_until` also applies to splice negotiation. If a
+  splice cannot complete before `valid_until`, the LSP MAY fail the buy or fall
+  back to opening a new channel.
+* If splicing cannot be negotiated or no splicing-capable channel exists with
+  the client, the LSP MAY open a new channel instead.
 
 Clients MAY reject the channel open attempt if any other
 parameters or options are not desired by the client (for example,


### PR DESCRIPTION
Adapts the current LSPS2 spec to also support splicing a channel instead of opening a channel If the LSP and client already share a channel that supports splicing.