### PR TITLE
LSPS: Add optional client_info field for client and node identification

### DIFF
--- a/blip-0050.md
+++ b/blip-0050.md
@@ -1073,6 +1073,46 @@ Example:
 }
 ```
 
+### Client Info
+
+###### Link: LSPS0.client_info
+
+An optional object that allows the client to identify its application
+and node implementation to the LSP.
+This can be used by LSPs for analytics, debugging, and compatibility
+purposes.
+
+All fields are optional JSON strings of at most 64 bytes each.
+The client MAY omit any or all fields.
+The client MAY omit the entire `client_info` object.
+
+The LSP MUST NOT require `client_info` to be present.
+The LSP MUST NOT use `client_info` to discriminate against clients
+(e.g. by offering worse terms based on the client application or
+node implementation).
+
+```JSON
+{
+  "client_info": {
+    "app": "ZEUS",
+    "app_version": "0.13.0-beta1",
+    "node": "Core Lightning",
+    "node_version": "25.12.1"
+  }
+}
+```
+
+- `app <string>` The name of the client application.
+- `app_version <string>` The version of the client application.
+- `node <string>` The name of the Lightning node implementation.
+- `node_version <string>` The version of the Lightning node implementation.
+
+> **Rationale** LSPs benefit from knowing which client applications
+> and node implementations are using their services, for debugging
+> and analytics. Defining this as a common schema avoids each LSPS
+> specification from independently reinventing client identification
+> or overloading the `token` field for this purpose.
+
 ### Error Codes
 
 Commonly shared error codes that are used in multiple LSPS.

--- a/blip-0051.md
+++ b/blip-0051.md
@@ -140,7 +140,13 @@ The request is constructed depending on the client's needs.
   "channel_expiry_blocks": 144,
   "token": "",
   "refund_onchain_address": "bc1qvmsy0f3yyes6z9jvddk8xqwznndmdwapvrc0xrmhd3vqj5rhdrrq6hz49h",
-  "announce_channel": true
+  "announce_channel": true,
+  "client_info": {
+    "app": "ZEUS",
+    "app_version": "0.13.0-beta1",
+    "node": "Core Lightning",
+    "node_version": "25.12.1"
+  }
 }
 ```
 
@@ -168,6 +174,8 @@ The request is constructed depending on the client's needs.
   - Client MAY omit this field.
   - LSP MUST disable on-chain payments if the client omits this field.
 - `announce_channel <boolean>` If the channel should be announced to the network (also known as public/private channels).
+- `client_info` <[LSPS0.client_info][]> Optional object identifying the client application and node implementation.
+  - Client MAY omit this field.
 
 
 > **Rationale `client_balance_sat`** Client MAY want to have initial spending balance on their wallet or start with a balanced channel.
@@ -577,4 +585,5 @@ For orders where `required_channel_confirmations = 0` the LSP MUST attempt to op
 [LSPS0.outpoint]: ./blip-0050.md#link-lsps0outpoint
 [LSPS0.scid]: ./blip-0050.md#link-lsps0scid
 [LSPS0.txid]: ./blip-0050.md#link-lsps0txid
+[LSPS0.client_info]: ./blip-0050.md#link-lsps0client_info
 [LSPS0.client_rejected_error]: ./blip-0050.md#link-lsps0client_rejected_error

--- a/blip-0052.md
+++ b/blip-0052.md
@@ -199,7 +199,13 @@ LSP and its related parameters.
 
 ```JSON
 {
-  "token": "SECRETDISCOUNTCOUPON100"
+  "token": "SECRETDISCOUNTCOUPON100",
+  "client_info": {
+    "app": "ZEUS",
+    "app_version": "0.13.0-beta1",
+    "node": "Core Lightning",
+    "node_version": "25.12.1"
+  }
 }
 ```
 
@@ -209,6 +215,9 @@ may be used to negotiate for a better fee rate than the LSP otherwise
 offers (i.e. a "discount coupon"), or for the LSP to actually offer
 this service to the client (i.e. an "API key") instead of failing to
 provide any offers, or for any other purpose.
+
+`client_info` is an *optional* object as defined in <[LSPS0.client_info][]>,
+identifying the client application and node implementation.
 
 `lsps2.get_info` has the following errors defined (error code numbers
 in parentheses):
@@ -1033,4 +1042,5 @@ also for onion messages.
 [<LSPS0.ppm>]: ./blip-0050.md#link-lsps0ppm
 [<LSPS0.datetime>]: ./blip-0050.md#link-lsps0datetime
 [<LSPS0.scid>]: ./blip-0050.md#link-lsps0scid
+[LSPS0.client_info]: ./blip-0050.md#link-lsps0client_info
 [LSPS0.client_rejected_error]: ./blip-0050.md#link-lsps0client_rejected_error


### PR DESCRIPTION
## Summary

- Adds an optional `client_info` object to LSPS0 Common Schemas (bLIP 50) for identifying client applications and node implementations
- References `client_info` from `lsps1.create_order` (bLIP 51) and `lsps2.get_info` (bLIP 52)
- All fields are optional strings (max 64 bytes): `app`, `app_version`, `node`, `node_version`

## Motivation

LSPs currently have no standardized way to know which client applications or node implementations are using their services. Some implementations work around this by overloading the `token` field, but this conflicts with its intended purpose (discount codes, API keys). A dedicated `client_info` object cleanly separates client identification from authentication/authorization, enabling better debugging and analytics without sacrificing the `token` field.

## Design Decisions

- **Defined in LSPS0** rather than per-spec to avoid duplication — any LSPS method can reference it
- **All fields optional** — clients can send as much or as little as they want
- **Free-form strings** — no enforced casing or versioning format (e.g. `"0.13.0-beta1"` is valid)
- **LSPs MUST NOT require it** and **MUST NOT use it for discriminatory behavior**