### PR TITLE
Add error failures to DNSSEC lookups

### DIFF
--- a/blip-0002.md
+++ b/blip-0002.md
@@ -133,6 +133,7 @@ The following table contains tlv fields for use in onion messages as the payload
 |-------|-----------------------------|--------------------------------|
 | 65536 | `dnssec_query`              | [bLIP 32](./blip-0032.md)      |
 | 65538 | `dnssec_proof`              | [bLIP 32](./blip-0032.md)      |
+| 65550 | `dnssec_error`              | [bLIP 32](./blip-0032.md)      |
 
 #### `invoice_request`
 

--- a/blip-0032.md
+++ b/blip-0032.md
@@ -32,6 +32,12 @@ Two new onion messages are defined, `dnssec_query` and `dnssec_proof`.
     * [`u16`:`proof_len`]
     * [`proof_len*byte`:`proof`]
 
+1. type: 65550 (`dnssec_error`)
+2. data:
+    * [`u8`:`domain_name_len`]
+    * [`domain_name_len*byte`:`domain_name`]
+    * [`bool`: `definitely_unresolvable`]
+
 Nodes which accept and reply to `dnssec_query`-containing onion messages from any sender:
  * SHOULD set the `dns_resolver` feature flag in their `node_announcement`.
 
@@ -50,10 +56,20 @@ Recipients of a `dnssec_query`-containing onion message:
    field at the start of a `DnssecChainExtension`).
  * SHOULD return the RFC 9102-formatted DNSSEC proof proving the resulting TXT records in a
    `dnssec_proof`-containing onion message to the sender using the provided `reply_path`.
+ If name resolution fails for any reason:
+   * SHOULD return a `dnssec_error` message.
 
 Senders of a `dnssec_proof`-containing onion message:
  * MUST set the `domain_name` to the `domain_name` included in the `dnssec_query`-containing onion
    message being responded to.
+
+Senders of a `dnssec_error`-containing onion message:
+ * MUST set the `domain_name` to the `domain_name` included in the `dnssec_query`-containing onion
+   message being responded to.
+ If the requested name does not exist (NXDOMAIN) or is not DNSSEC-signed:
+   * SHOULD set `definitely_unresolvable`
+ otherwise:
+   * MUST NOT set `definitely_unresolvable`.
 
 Recipients of a `dnssec_proof`-containing onion message:
  * MUST validate all DNSSEC signatures to ensure any contained records are signed in an unbroken


### PR DESCRIPTION
Not sure really why these weren't included, whether they can be trusted or not its very useful to have a resolver indicate you shouldn't wait around any longer for a response.